### PR TITLE
Escaping namespace separators

### DIFF
--- a/en/reference/input_output_customization.rst
+++ b/en/reference/input_output_customization.rst
@@ -4,7 +4,7 @@
 Input - Output Customization
 ============================
 
-Behind the scenes Doctrine Migration uses `\Symfony\Component\Console\Input\ArgvInput`
+Behind the scenes Doctrine Migration uses `\\Symfony\\Component\\Console\\Input\\ArgvInput`
 to capture and parse values from `$_SERVER['argv']`.
 
 You can customize the input like the following:


### PR DESCRIPTION
Backslashes are swallowed during rendering when they are alone